### PR TITLE
Fix path closure and cleanup import

### DIFF
--- a/lib/components/center_widget/center_widget.dart
+++ b/lib/components/center_widget/center_widget.dart
@@ -61,7 +61,7 @@ class CenterWidget extends StatelessWidget {
       height,
     );
     path.lineTo(0, height);
-    path.close;
+    path.close();
 
     return Stack(
       children: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
 import 'Theme/ThemeNotifier.dart';
-import 'firebase_options.dart';
 import 'WorldNews.dart';
 import 'firebase_options.dart';
 import 'onBoarding/ConfiguracionView.dart';


### PR DESCRIPTION
## Summary
- fix missing parentheses in `path.close()`
- remove duplicate `firebase_options.dart` import

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840085b65d88321a10af33a05fb8d61